### PR TITLE
Use test case serialization to remove xunit.core dependency

### DIFF
--- a/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
@@ -11,13 +11,14 @@ namespace xunit.runner.wpf.ViewModel
 {
     public class TestCaseViewModel : ViewModelBase
     {
-        public TestCaseViewModel(ITestCase testCase, string assemblyFileName)
+        public TestCaseViewModel(string testCase, string displayName, string assemblyFileName)
         {
             this.TestCase = testCase;
+            this.DisplayName = displayName;
             this.AssemblyFileName = assemblyFileName;
         }
 
-        public string DisplayName => TestCase.DisplayName;
+        public string DisplayName { get; }
 
         private TestState state = TestState.NotRun;
         public TestState State
@@ -28,6 +29,6 @@ namespace xunit.runner.wpf.ViewModel
 
         public string AssemblyFileName { get; }
 
-        public ITestCase TestCase { get; }
+        public string TestCase { get; }
     }
 }

--- a/xunit.runner.wpf/packages.config
+++ b/xunit.runner.wpf/packages.config
@@ -4,7 +4,5 @@
   <package id="MvvmLight" version="5.1.1.0" targetFramework="net452" />
   <package id="MvvmLightLibs" version="5.1.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0-beta4-build3109" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0-beta4-build3109" targetFramework="net452" />
   <package id="xunit.runner.utility" version="2.1.0-beta4-build3109" targetFramework="net452" />
 </packages>

--- a/xunit.runner.wpf/xunit.runner.wpf.csproj
+++ b/xunit.runner.wpf/xunit.runner.wpf.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -74,10 +73,6 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0-beta4-build3109\lib\dotnet\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -154,12 +149,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Resolve the crashing issues when using app domain, by using test case serialization. This allows the app domain to be shut down between discovery and execution (otherwise, the `ITestCase` objects become disconnected from the original app domain).

Alternatively, you could track the `XunitFrontController` with the test assembly, so that it stays open so long as the test assembly stays open. Then you can keep the references to the `ITestCase` objects, since their remote app domain stays alive.