### PR TITLE
Use darker yellow for "skipped" ProgressBar foreground

### DIFF
--- a/xunit.runner.wpf/Converters/TestStateConverter.cs
+++ b/xunit.runner.wpf/Converters/TestStateConverter.cs
@@ -16,6 +16,9 @@ namespace xunit.runner.wpf.Converters
         private static ImageSource passedSource;
         private static ImageSource failedSource;
         private static ImageSource skippedSource;
+
+        private static SolidColorBrush skippedBrush = new SolidColorBrush(Color.FromRgb(0xEB, 0xCA, 0x00));
+
         static TestStateConverter()
         {
             passedSource = LoadResourceImage("Passed.ico");
@@ -42,7 +45,7 @@ namespace xunit.runner.wpf.Converters
                     case TestState.Failed:
                         return Brushes.Red;
                     case TestState.Skipped:
-                        return Brushes.Yellow;
+                        return skippedBrush;
                     case TestState.Passed:
                         return Brushes.Green;
                     default:


### PR DESCRIPTION
Fixes #15

Switch the yellow color used in the ProgressBar for skipped tests from
Brushes.Yellow (#FFFF00) to #EBCA00.