### PR TITLE
Make worker source compatible with .NET Core

### DIFF
--- a/xunit.runner.data/TestCaseData.cs
+++ b/xunit.runner.data/TestCaseData.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 
 namespace xunit.runner.data
 {
@@ -19,19 +18,44 @@ namespace xunit.runner.data
 
         public static TestCaseData ReadFrom(BinaryReader reader)
         {
-            var formatter = new BinaryFormatter();
             var displayName = reader.ReadString();
             var assemblyPath = reader.ReadString();
-            var traitMap = (Dictionary<string, List<string>>)formatter.Deserialize(reader.BaseStream);
+            var count = reader.ReadInt32();
+            var traitMap = new Dictionary<string, List<string>>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                var key = reader.ReadString();
+                var valueCount = reader.ReadInt32();
+                var values = new List<string>(valueCount);
+
+                for (int j = 0; j < valueCount; j++)
+                {
+                    values.Add(reader.ReadString());
+                }
+
+                traitMap.Add(key, values);
+            }
+
             return new TestCaseData(displayName, assemblyPath, traitMap);
         }
 
         public void WriteTo(BinaryWriter writer)
         {
-            var formatter = new BinaryFormatter();
             writer.Write(DisplayName);
             writer.Write(AssemblyPath);
-            formatter.Serialize(writer.BaseStream, TraitMap);
+            writer.Write(TraitMap.Count);
+
+            foreach (var pair in TraitMap)
+            {
+                writer.Write(pair.Key);
+                writer.Write(pair.Value.Count);
+
+                foreach (var value in pair.Value)
+                {
+                    writer.Write(value);
+                }
+            }
         }
     }
 }

--- a/xunit.runner.worker/Connection.cs
+++ b/xunit.runner.worker/Connection.cs
@@ -56,7 +56,7 @@ namespace xunit.runner.worker
 
         protected override void DisposeCore()
         {
-            _stream.Close();
+            _stream.Dispose();
         }
 
         internal override void WaitForClientConnect()

--- a/xunit.runner.worker/Listener.cs
+++ b/xunit.runner.worker/Listener.cs
@@ -37,7 +37,7 @@ namespace xunit.runner.worker
         {
             try
             {
-                var namedPipe = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances);
+                var namedPipe = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, maxNumberOfServerInstances: -1);
                 namedPipe.WaitForConnection();
                 _taskList.Add(Task.Run(() => ProcessConnection(namedPipe)));
 

--- a/xunit.runner.worker/Program.cs
+++ b/xunit.runner.worker/Program.cs
@@ -32,17 +32,11 @@ namespace xunit.runner.worker
                 return ExitError;
             }
 
-            Task.Run(() => WaitForParentExit(process));
+            Task.WaitAny(
+                Task.Run(() => process.WaitForExit()),
+                Task.Run(() => new Listener(pipeName).Go()));
 
-            var listener = new Listener(pipeName);
-            listener.Go();
             return ExitSuccess;
-        }
-
-        private static void WaitForParentExit(Process process)
-        {
-            process.WaitForExit();
-            Environment.Exit(ExitSuccess);
         }
 
         private static void Usage()


### PR DESCRIPTION
First step towards running tests on CoreCLR. This makes it so that the worker can successfully compile against .NET Core packages, but leaves the actual project targeting intact.

* Work around lack of Environment.Exit
* Eliminate dependency on binary serializer
* Close -> Dispose
* Inline NamedPipeServerStream.MaxAllowedServerInstances = -1

@Pilchie @jaredpar 