### PR TITLE
Improve start up performance of test runs

### DIFF
--- a/xunit.runner.worker/DiscoverUtil.cs
+++ b/xunit.runner.worker/DiscoverUtil.cs
@@ -1,49 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 using xunit.runner.data;
-using System.Threading;
 
 namespace xunit.runner.worker
 {
     internal sealed class DiscoverUtil
     {
-        private sealed class Impl : LongLivedMarshalByRefObject, IMessageSink, IDisposable
+        private sealed class Impl : TestDiscoverySink
         {
-            private readonly ITestFrameworkDiscoverer _discoverer;
             private readonly ClientWriter _writer;
 
-            public ManualResetEvent Finished { get; private set; }
-
-            internal Impl(ITestFrameworkDiscoverer discoverer, ClientWriter writer)
+            internal Impl(ClientWriter writer)
             {
-                Finished = new ManualResetEvent(false);
-                _discoverer = discoverer;
                 _writer = writer;
             }
 
-            public bool OnMessage(IMessageSinkMessage message)
-            {
-                var discoveryMessage = message as ITestCaseDiscoveryMessage;
-                if (discoveryMessage != null)
-                {
-                    OnDiscoveryMessage(discoveryMessage);
-                }
+            protected override bool ShouldContinue => _writer.IsConnected;
 
-                if (message is IDiscoveryCompleteMessage)
-                {
-                    Finished.Set();
-                }
-
-                return _writer.IsConnected;
-            }
-
-            private bool OnDiscoveryMessage(ITestCaseDiscoveryMessage testCaseDiscovered)
+            protected override void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered)
             {
                 var testCase = testCaseDiscovered.TestCase;
                 var testCaseData = new TestCaseData(
@@ -53,13 +28,6 @@ namespace xunit.runner.worker
 
                 _writer.Write(TestDataKind.Value);
                 _writer.Write(testCaseData);
-
-                return _writer.IsConnected;
-            }
-
-            public void Dispose()
-            {
-                ((IDisposable)Finished).Dispose();
             }
         }
 
@@ -72,7 +40,7 @@ namespace xunit.runner.worker
                 diagnosticMessageSink: new MessageVisitor(),
                 shadowCopy: false))
             using (var writer = new ClientWriter(stream))
-            using (var impl = new Impl(xunit, writer))
+            using (var impl = new Impl(writer))
             {
                 xunit.Find(includeSourceInformation: false, messageSink: impl, discoveryOptions: TestFrameworkOptions.ForDiscovery());
                 impl.Finished.WaitOne();

--- a/xunit.runner.worker/RunUtil.cs
+++ b/xunit.runner.worker/RunUtil.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using xunit.runner.data;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,7 +61,7 @@ namespace xunit.runner.worker
             }
         }
 
-        private sealed class TestCaseDiscoverer : TestMessageVisitor<IDiscoveryCompleteMessage>
+        private sealed class TestCaseDiscoverer : TestDiscoverySink
         {
             private readonly HashSet<string> _testCaseDisplayNameSet;
             private readonly List<ITestCase> _testCaseList;
@@ -74,15 +72,13 @@ namespace xunit.runner.worker
                 _testCaseList = testCaseList;
             }
 
-            protected override bool Visit(ITestCaseDiscoveryMessage testCaseDiscovered)
+            protected override void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered)
             {
                 var testCase = testCaseDiscovered.TestCase;
                 if (_testCaseDisplayNameSet.Contains(testCase.DisplayName))
                 {
                     _testCaseList.Add(testCaseDiscovered.TestCase);
                 }
-
-                return true;
             }
         }
 

--- a/xunit.runner.worker/TestDiscoverySink.cs
+++ b/xunit.runner.worker/TestDiscoverySink.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace xunit.runner.worker
+{
+    internal abstract class TestDiscoverySink : LongLivedMarshalByRefObject, IMessageSink, IDisposable
+    {
+        public ManualResetEvent Finished { get; }
+
+        protected TestDiscoverySink()
+        {
+            Finished = new ManualResetEvent(false);
+        }
+
+        public bool OnMessage(IMessageSinkMessage message)
+        {
+            var discoveryMessage = message as ITestCaseDiscoveryMessage;
+            if (discoveryMessage != null)
+            {
+                OnTestDiscovered(discoveryMessage);
+            }
+
+            if (message is IDiscoveryCompleteMessage)
+            {
+                Finished.Set();
+            }
+
+            return ShouldContinue;
+        }
+
+        protected virtual bool ShouldContinue => true;
+
+        protected abstract void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered);
+
+        public void Dispose()
+        {
+            Finished.Dispose();
+        }
+    }
+}

--- a/xunit.runner.worker/xunit.runner.worker.csproj
+++ b/xunit.runner.worker/xunit.runner.worker.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RunUtil.cs" />
+    <Compile Include="TestDiscoverySink.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
Before a test run, we collect all of the test cases to use in the run. Unfortuantely, we were using the same slower test discovery mechanism that we previously used when loading test assemblies. This change switches that code path to use the faster mechanism that we've already put in place.