### PR TITLE
Save and restore the position of the Main window

### DIFF
--- a/xunit.runner.wpf/MainWindow.xaml
+++ b/xunit.runner.wpf/MainWindow.xaml
@@ -15,7 +15,8 @@
         Icon="Artwork\Application.ico"
         ResizeMode="CanResizeWithGrip"
         Height="600"
-        Width="525">
+        Width="525"
+        Name="Main">
 
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Loaded">

--- a/xunit.runner.wpf/MainWindow.xaml.cs
+++ b/xunit.runner.wpf/MainWindow.xaml.cs
@@ -1,25 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace xunit.runner.wpf
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
     public partial class MainWindow : Window
     {
+        public static Window Instance { get; private set; }
+
         public MainWindow()
         {
             Instance = this;
@@ -27,6 +15,18 @@ namespace xunit.runner.wpf
             InitializeComponent();
         }
 
-        public static Window Instance { get; private set; }
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+
+            Storage.RestoreWindowLayout(this);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            Storage.SaveWindowLayout(this);
+
+            base.OnClosing(e);
+        }
     }
 }

--- a/xunit.runner.wpf/Storage.WindowPlacement.cs
+++ b/xunit.runner.wpf/Storage.WindowPlacement.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Xml.Linq;
+
+namespace xunit.runner.wpf
+{
+    internal static partial class Storage
+    {
+        private static class WindowPlacement
+        {
+            [StructLayout(LayoutKind.Sequential)]
+            private struct RECT
+            {
+                public int left;
+                public int top;
+                public int right;
+                public int bottom;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct POINT
+            {
+                public int x;
+                public int y;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct WINDOWPLACEMENT
+            {
+                public int length;
+                public int flags;
+                public int showCmd;
+                public POINT ptMinPosition;
+                public POINT ptMaxPosition;
+                public RECT rcNormalPosition;
+            }
+
+            private const int SW_SHOWNORMAL = 1;
+            private const int SW_SHOWMINIMIZED = 2;
+
+            [DllImport("user32.dll")]
+            private static extern bool SetWindowPlacement(IntPtr hWnd, [In] ref WINDOWPLACEMENT lpwndpl);
+
+            [DllImport("user32.dll")]
+            private static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+
+            private const string WindowPlacementElementName = "window_placement";
+            private const string ShowCommandElementName = "show_command";
+            private const string MinPositionElementName = "min_position";
+            private const string MaxPositionElementName = "max_position";
+            private const string NormalPositionElementName = "normal_position";
+            private const string XAttributeName = "x";
+            private const string YAttributeName = "y";
+            private const string LeftAttributeName = "left";
+            private const string TopAttributeName = "top";
+            private const string RightAttributeName = "right";
+            private const string BottomAttributeName = "bottom";
+
+            public static void Restore(Window window, XElement xml)
+            {
+                var placement = new WINDOWPLACEMENT();
+
+                placement.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+                placement.flags = 0;
+
+                placement.showCmd = (int)xml.Element(ShowCommandElementName);
+                placement.ptMinPosition.x = (int)xml.Element(MinPositionElementName).Attribute(XAttributeName);
+                placement.ptMinPosition.y = (int)xml.Element(MinPositionElementName).Attribute(YAttributeName);
+                placement.ptMaxPosition.x = (int)xml.Element(MaxPositionElementName).Attribute(XAttributeName);
+                placement.ptMaxPosition.y = (int)xml.Element(MaxPositionElementName).Attribute(YAttributeName);
+                placement.rcNormalPosition.left = (int)xml.Element(NormalPositionElementName).Attribute(LeftAttributeName);
+                placement.rcNormalPosition.top = (int)xml.Element(NormalPositionElementName).Attribute(TopAttributeName);
+                placement.rcNormalPosition.right = (int)xml.Element(NormalPositionElementName).Attribute(RightAttributeName);
+                placement.rcNormalPosition.bottom = (int)xml.Element(NormalPositionElementName).Attribute(BottomAttributeName);
+
+                var windowInteropHelper = new WindowInteropHelper(window);
+                SetWindowPlacement(windowInteropHelper.Handle, ref placement);
+            }
+
+            public static XElement Save(Window window)
+            {
+                var windowInteropHelper = new WindowInteropHelper(window);
+                var placement = new WINDOWPLACEMENT();
+                GetWindowPlacement(windowInteropHelper.Handle, out placement);
+
+                return
+                    new XElement(WindowPlacementElementName,
+                        new XElement(ShowCommandElementName, (placement.showCmd == SW_SHOWMINIMIZED ? SW_SHOWNORMAL : placement.showCmd)),
+                        new XElement(MinPositionElementName,
+                            new XAttribute(XAttributeName, placement.ptMinPosition.x),
+                            new XAttribute(YAttributeName, placement.ptMinPosition.y)),
+                        new XElement(MaxPositionElementName,
+                            new XAttribute(XAttributeName, placement.ptMaxPosition.x),
+                            new XAttribute(YAttributeName, placement.ptMaxPosition.y)),
+                        new XElement(NormalPositionElementName,
+                            new XAttribute(LeftAttributeName, placement.rcNormalPosition.left),
+                            new XAttribute(TopAttributeName, placement.rcNormalPosition.top),
+                            new XAttribute(RightAttributeName, placement.rcNormalPosition.right),
+                            new XAttribute(BottomAttributeName, placement.rcNormalPosition.bottom)));
+            }
+        }
+    }
+}

--- a/xunit.runner.wpf/Storage.cs
+++ b/xunit.runner.wpf/Storage.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.IO;
+using System.IO.IsolatedStorage;
+using System.Text;
+using System.Windows;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace xunit.runner.wpf
+{
+    internal static partial class Storage
+    {
+        private const string WindowLayoutFileName = "window_layout.xml";
+
+        private static string GetWindowLayoutFileName(Window window) => $"{window.Name}_{WindowLayoutFileName}";
+
+        private static IsolatedStorageFile GetStorageFile() => IsolatedStorageFile.GetUserStoreForDomain();
+
+        public static XmlTextReader OpenXmlFile(string fileName)
+        {
+            var storage = GetStorageFile();
+            if (!storage.FileExists(fileName))
+            {
+                return null;
+            }
+
+            var fileStream = storage.OpenFile(fileName, FileMode.Open, FileAccess.Read);
+            var reader = new XmlTextReader(fileStream);
+            reader.WhitespaceHandling = WhitespaceHandling.None;
+
+            return reader;
+        }
+
+        public static XmlTextWriter CreateXmlFile(string fileName)
+        {
+            var storage = GetStorageFile();
+            var fileStream = storage.CreateFile(fileName);
+            var writer = new XmlTextWriter(fileStream, Encoding.UTF8);
+            writer.Formatting = Formatting.Indented;
+
+            return writer;
+        }
+
+        public static void RestoreWindowLayout(Window window)
+        {
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window));
+            }
+
+            if (string.IsNullOrWhiteSpace(window.Name))
+            {
+                throw new ArgumentException("Name is not set.", nameof(window));
+            }
+
+            using (var windowLayoutReader = OpenXmlFile(GetWindowLayoutFileName(window)))
+            {
+                if (windowLayoutReader != null)
+                {
+                    windowLayoutReader.MoveToContent();
+                    var xml = XElement.Load(windowLayoutReader);
+                    WindowPlacement.Restore(window, xml);
+                }
+            }
+        }
+
+        public static void SaveWindowLayout(Window window)
+        {
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window));
+            }
+
+            if (string.IsNullOrWhiteSpace(window.Name))
+            {
+                throw new ArgumentException("Name is not set.", nameof(window));
+            }
+
+            using (var windowLayoutWriter = CreateXmlFile(GetWindowLayoutFileName(window)))
+            {
+                var xml = WindowPlacement.Save(window);
+                xml.Save(windowLayoutWriter);
+            }
+        }
+    }
+}

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -1,19 +1,19 @@
-using GalaSoft.MvvmLight;
-using System.Windows.Input;
 using System;
-using System.Windows;
-using GalaSoft.MvvmLight.CommandWpf;
-using Microsoft.Win32;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
-using xunit.runner.data;
+using System.Windows;
+using System.Windows.Input;
 using System.Windows.Threading;
+using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.CommandWpf;
+using Microsoft.Win32;
+using xunit.runner.data;
 
 namespace xunit.runner.wpf.ViewModel
 {

--- a/xunit.runner.wpf/xunit.runner.wpf.csproj
+++ b/xunit.runner.wpf/xunit.runner.wpf.csproj
@@ -100,6 +100,8 @@
     <Compile Include="LoadingDialog.xaml.cs">
       <DependentUpon>LoadingDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Storage.cs" />
+    <Compile Include="Storage.WindowPlacement.cs" />
     <Compile Include="ViewModel\TraitCollectionView.cs" />
     <Compile Include="ViewModel\AssemblyAndConfigFile.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />


### PR DESCRIPTION
It's pretty annoying that the XUnit runner always starts with the same width and height. This change adds code to save and restore the position. It uses the Win32 `GetWindowPlacement` and `SetWindowPlacement` APIs to ensure that the normal position is properly saved and restored regardless of whether the window is maximized or not.

Please review this @Pilchie