### PR TITLE
Invert test case filter buttons and mark skipped tests during discovery

### DIFF
--- a/xunit.runner.data/TestCaseData.cs
+++ b/xunit.runner.data/TestCaseData.cs
@@ -6,12 +6,14 @@ namespace Xunit.Runner.Data
     public sealed class TestCaseData
     {
         public string DisplayName { get; set; }
+        public string SkipReason { get; set; }
         public string AssemblyPath { get; set; }
         public Dictionary<string, List<string>> TraitMap { get; set; }
 
-        public TestCaseData(string displayName, string assemblyPath, Dictionary<string, List<string>> traitMap)
+        public TestCaseData(string displayName, string skipReason, string assemblyPath, Dictionary<string, List<string>> traitMap)
         {
             DisplayName = displayName;
+            SkipReason = skipReason;
             AssemblyPath = assemblyPath;
             TraitMap = traitMap;
         }
@@ -19,6 +21,7 @@ namespace Xunit.Runner.Data
         public static TestCaseData ReadFrom(BinaryReader reader)
         {
             var displayName = reader.ReadString();
+            var skipReason = reader.ReadString();
             var assemblyPath = reader.ReadString();
             var count = reader.ReadInt32();
             var traitMap = new Dictionary<string, List<string>>(count);
@@ -37,12 +40,13 @@ namespace Xunit.Runner.Data
                 traitMap.Add(key, values);
             }
 
-            return new TestCaseData(displayName, assemblyPath, traitMap);
+            return new TestCaseData(displayName, skipReason, assemblyPath, traitMap);
         }
 
         public void WriteTo(BinaryWriter writer)
         {
             writer.Write(DisplayName);
+            writer.Write(SkipReason ?? string.Empty);
             writer.Write(AssemblyPath);
             writer.Write(TraitMap.Count);
 

--- a/xunit.runner.worker/DiscoverUtil.cs
+++ b/xunit.runner.worker/DiscoverUtil.cs
@@ -23,6 +23,7 @@ namespace Xunit.Runner.Worker
                 var testCase = testCaseDiscovered.TestCase;
                 var testCaseData = new TestCaseData(
                     testCase.DisplayName,
+                    testCase.SkipReason,
                     testCaseDiscovered.TestAssembly.Assembly.AssemblyPath,
                     testCase.Traits);
 

--- a/xunit.runner.wpf/MainWindow.xaml
+++ b/xunit.runner.wpf/MainWindow.xaml
@@ -215,11 +215,12 @@
                         </Grid.RowDefinitions>
 
                         <StackPanel Orientation="Horizontal">
-                            <ToggleButton IsChecked="{Binding IncludePassedTests}"
+                            <ToggleButton IsChecked="{Binding FilterPassedTests}"
                                           BorderThickness="0"
                                           Background="Transparent"
                                           Margin="0,4,2,4"
-                                          Grid.Column="0">
+                                          Grid.Column="0"
+                                          Command="{Binding TestFilterChanged}">
                                 <StackPanel Orientation="Horizontal">
                                     <Image Source="Artwork\Passed_large.png" />
                                     <TextBlock Margin="4,0"
@@ -229,11 +230,12 @@
                                 </StackPanel>
                             </ToggleButton>
 
-                            <ToggleButton IsChecked="{Binding IncludeFailedTests}"
+                            <ToggleButton IsChecked="{Binding FilterFailedTests}"
                                           BorderThickness="0"
                                           Background="Transparent"
                                           Margin="2,4"
-                                          Grid.Column="1">
+                                          Grid.Column="1"
+                                          Command="{Binding TestFilterChanged}">
                                 <StackPanel Orientation="Horizontal">
                                     <Image Source="Artwork\Failed_large.png" />
                                     <TextBlock Margin="4,0"
@@ -243,11 +245,12 @@
                                 </StackPanel>
                             </ToggleButton>
 
-                            <ToggleButton IsChecked="{Binding IncludeSkippedTests}"
+                            <ToggleButton IsChecked="{Binding FilterSkippedTests}"
                                           BorderThickness="0"
                                           Background="Transparent"
                                           Margin="2,4,0,4"
-                                          Grid.Column="2">
+                                          Grid.Column="2"
+                                          Command="{Binding TestFilterChanged}">
                                 <StackPanel Orientation="Horizontal">
                                     <Image Source="Artwork\Skipped_large.png" />
                                     <TextBlock Margin="4,0"
@@ -273,6 +276,7 @@
                                                Margin="0,0,2,0"
                                                Source="{Binding Path=State, Mode=OneWay, Converter={StaticResource TestStateConverter}}"
                                                Grid.Column="0" />
+
                                         <TextBlock Text="{Binding DisplayName}"
                                                    VerticalAlignment="Center"
                                                    Grid.Column="1" />

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -84,19 +84,21 @@ namespace Xunit.Runner.Wpf.ViewModel
                 }
             }
 
+            var noFilter = !(searchQuery.FilterFailedTests | searchQuery.FilterPassedTests | searchQuery.FilterSkippedTests);
+
             switch (testCase.State)
             {
                 case TestState.Passed:
-                    return searchQuery.IncludePassedTests;
+                    return noFilter || searchQuery.FilterPassedTests;
 
                 case TestState.Skipped:
-                    return searchQuery.IncludeSkippedTests;
+                    return noFilter || searchQuery.FilterSkippedTests;
 
                 case TestState.Failed:
-                    return searchQuery.IncludeFailedTests;
+                    return noFilter || searchQuery.FilterFailedTests;
 
                 case TestState.NotRun:
-                    return true;
+                    return noFilter;
 
                 default:
                     Debug.Assert(false, "What state is this test case in?");
@@ -527,8 +529,14 @@ namespace Xunit.Runner.Wpf.ViewModel
 
                 var testCaseViewModel = new TestCaseViewModel(
                     testCase.DisplayName,
+                    testCase.SkipReason,
                     testCase.AssemblyPath,
                     traitWorkerList);
+
+                if (testCaseViewModel.State == TestState.Skipped)
+                {
+                    TestsSkipped++;
+                }
 
                 this.allTestCases.Add(testCaseViewModel);
             }
@@ -623,36 +631,36 @@ namespace Xunit.Runner.Wpf.ViewModel
             RemoveAssemblies(Assemblies.ToArray());
         }
 
-        public bool IncludePassedTests
+        public bool FilterPassedTests
         {
-            get { return searchQuery.IncludePassedTests; }
+            get { return searchQuery.FilterPassedTests; }
             set
             {
-                if (Set(ref searchQuery.IncludePassedTests, value))
+                if (Set(ref searchQuery.FilterPassedTests, value))
                 {
                     FilterAfterDelay();
                 }
             }
         }
 
-        public bool IncludeFailedTests
+        public bool FilterFailedTests
         {
-            get { return searchQuery.IncludeFailedTests; }
+            get { return searchQuery.FilterFailedTests; }
             set
             {
-                if (Set(ref searchQuery.IncludeFailedTests, value))
+                if (Set(ref searchQuery.FilterFailedTests, value))
                 {
                     FilterAfterDelay();
                 }
             }
         }
 
-        public bool IncludeSkippedTests
+        public bool FilterSkippedTests
         {
-            get { return searchQuery.IncludeSkippedTests; }
+            get { return searchQuery.FilterSkippedTests; }
             set
             {
-                if (Set(ref searchQuery.IncludeSkippedTests, value))
+                if (Set(ref searchQuery.FilterSkippedTests, value))
                 {
                     FilterAfterDelay();
                 }

--- a/xunit.runner.wpf/ViewModel/SearchQuery.cs
+++ b/xunit.runner.wpf/ViewModel/SearchQuery.cs
@@ -4,9 +4,9 @@ namespace Xunit.Runner.Wpf.ViewModel
 {
     public class SearchQuery
     {
-        public bool IncludeFailedTests = true;
-        public bool IncludePassedTests = true;
-        public bool IncludeSkippedTests = true;
+        public bool FilterFailedTests = false;
+        public bool FilterPassedTests = false;
+        public bool FilterSkippedTests = false;
         public string SearchString = string.Empty;
         public ISet<TraitViewModel> TraitSet = new HashSet<TraitViewModel>(TraitViewModel.EqualityComparer);
     }

--- a/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
@@ -9,14 +9,12 @@ namespace Xunit.Runner.Wpf.ViewModel
     {
         private TestState _state = TestState.NotRun;
 
-        public TestCaseViewModel(string displayName, string assemblyFileName, IEnumerable<TraitViewModel> traits)
-        {
-            this.DisplayName = displayName;
-            this.AssemblyFileName = assemblyFileName;
-            this.Traits = traits.ToImmutableArray();
-        }
-
         public string DisplayName { get; }
+        public string SkipReason { get; }
+        public string AssemblyFileName { get; }
+        public ImmutableArray<TraitViewModel> Traits { get; }
+
+        public bool HasSkipReason => !string.IsNullOrEmpty(this.SkipReason);
 
         public TestState State
         {
@@ -24,8 +22,17 @@ namespace Xunit.Runner.Wpf.ViewModel
             set { Set(ref _state, value); }
         }
 
-        public string AssemblyFileName { get; }
+        public TestCaseViewModel(string displayName, string skipReason, string assemblyFileName, IEnumerable<TraitViewModel> traits)
+        {
+            this.DisplayName = displayName;
+            this.SkipReason = skipReason;
+            this.AssemblyFileName = assemblyFileName;
+            this.Traits = traits.ToImmutableArray();
 
-        public ImmutableArray<TraitViewModel> Traits { get; }
+            if (!string.IsNullOrEmpty(skipReason))
+            {
+                _state = TestState.Skipped;
+            }
+        }
     }
 }


### PR DESCRIPTION
The filter buttons are now unchecked by default, which has the meaning of no filter applied. Clicking the filter buttons the applies that filter. In addition, we now mark skipped tests when they are discovered.

Tagging @Pilchie 