### PR TITLE
Fix progress bar and add support for running selected tests

### DIFF
--- a/xunit.runner.wpf/MainWindow.xaml
+++ b/xunit.runner.wpf/MainWindow.xaml
@@ -198,17 +198,19 @@
                   Grid.Row="1">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <Button Content="_Run All"
-                        Command="{Binding RunCommand}"
-                        Margin="3"
-                        Grid.Column="0" />
+                        Command="{Binding RunAllCommand}"
+                        Grid.Column="0" Margin="10,0,0,0"/>
+                <Button Content="Run _Selected"
+                        Command="{Binding RunSelectedCommand}"
+                        Grid.Column="1"/>
                 <Button Content="_Cancel"
                         Command="{Binding CancelCommand}"
-                        Margin="0,3,3,3"
-                        Grid.Column="1" />
+                        Grid.Column="2" Margin="0,0,10,0" />
             </Grid>
 
             <Grid Grid.Column="1"
@@ -275,9 +277,10 @@
                             </ToggleButton>
                         </StackPanel>
 
-                        <ListBox ItemsSource="{Binding FilteredTestCases}"
+                        <ListBox x:Name="TestCases" ItemsSource="{Binding FilteredTestCases}"
                                  SelectionMode="Extended"
-                                 Grid.Row="1">
+                                 SelectedItem="{Binding SelectedTestCase, Mode=TwoWay}"
+                                 Grid.Row="1" SelectionChanged="TestCases_SelectionChanged">
                             <ListBox.ItemTemplate>
                                 <DataTemplate DataType="vm:TestCaseViewModel">
                                     <Grid>
@@ -313,9 +316,9 @@
                              Text="{Binding Output}"/>
                 </GroupBox>
             </Grid>
-            
+
             <GridSplitter Grid.Column="0" VerticalAlignment="Stretch" Width="3" Background="White"/>
-            
+
             <ProgressBar Foreground="{Binding Path=CurrentRunState, Converter={StaticResource TestStateConverter}, Mode=OneWay}"
                          Minimum="0"
                          Maximum="{Binding MaximumProgress}"

--- a/xunit.runner.wpf/MainWindow.xaml.cs
+++ b/xunit.runner.wpf/MainWindow.xaml.cs
@@ -5,6 +5,8 @@ using Xunit.Runner.Wpf.Persistence;
 
 namespace Xunit.Runner.Wpf
 {
+    using ViewModel;
+
     public partial class MainWindow : Window
     {
         public static Window Instance { get; private set; }
@@ -28,6 +30,27 @@ namespace Xunit.Runner.Wpf
             Storage.SaveWindowLayout(this);
 
             base.OnClosing(e);
+        }
+
+        private void TestCases_SelectionChanged(Object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            foreach (var item in e.AddedItems)
+            {
+                var model = item as TestCaseViewModel;
+                if (model != null)
+                {
+                    model.IsSelected = true;
+                }
+            }
+
+            foreach (var item in e.RemovedItems)
+            {
+                var model = item as TestCaseViewModel;
+                if (model != null)
+                {
+                    model.IsSelected = false;
+                }
+            }
         }
     }
 }

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -177,14 +177,21 @@ namespace Xunit.Runner.Wpf.ViewModel
         public int TestsCompleted
         {
             get { return testsCompleted; }
-            set { Set(ref testsCompleted, value);
 
-                if (TaskbarManager.IsPlatformSupported)
-                {
-                    var tb = TaskbarManager.Instance;
-                    tb.SetProgressState(GetTaskBarState());
-                    tb.SetProgressValue(value, this.MaximumProgress);
-                }
+            set
+            {
+                Set(ref testsCompleted, value);
+                UpdateProgress();
+            }
+        }
+
+        private void UpdateProgress()
+        {
+            if (TaskbarManager.IsPlatformSupported)
+            {
+                var tb = TaskbarManager.Instance;
+                tb.SetProgressState(GetTaskBarState());
+                tb.SetProgressValue(this.TestsCompleted, this.MaximumProgress);
             }
         }
 
@@ -226,14 +233,24 @@ namespace Xunit.Runner.Wpf.ViewModel
         public int MaximumProgress
         {
             get { return maximumProgress; }
-            set { Set(ref maximumProgress, value); }
+
+            set
+            {
+                Set(ref maximumProgress, value);
+                UpdateProgress();
+            }
         }
 
         private TestState currentRunState;
         public TestState CurrentRunState
         {
             get { return currentRunState; }
-            set { Set(ref currentRunState, value); }
+
+            set
+            {
+                Set(ref currentRunState, value);
+                UpdateProgress();
+            }
         }
 
         private string output = string.Empty;

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -161,6 +161,15 @@ namespace Xunit.Runner.Wpf.ViewModel
         private void TestCases_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             UpdateTestCaseInfo(useSelected: false);
+            ClearSelectionFlags();
+        }
+
+        private void ClearSelectionFlags()
+        {
+            foreach (var test in this.allTestCases)
+            {
+                test.IsSelected = false;
+            }
         }
 
         void UpdateTestCaseInfo(bool useSelected)

--- a/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
@@ -13,6 +13,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         public string SkipReason { get; }
         public string AssemblyFileName { get; }
         public ImmutableArray<TraitViewModel> Traits { get; }
+        public bool IsSelected { get; set; }
 
         public bool HasSkipReason => !string.IsNullOrEmpty(this.SkipReason);
 


### PR DESCRIPTION
The progress bar will now be the correct color at all times.

You can now run just the selected test cases using the "Run Selected" button.