### PR TITLE
Fix crashes related to multiple tests with the same name

### DIFF
--- a/xunit.runner.data/TestCaseData.cs
+++ b/xunit.runner.data/TestCaseData.cs
@@ -6,13 +6,15 @@ namespace Xunit.Runner.Data
     public sealed class TestCaseData
     {
         public string DisplayName { get; set; }
+        public string UniqueID { get; set; }
         public string SkipReason { get; set; }
         public string AssemblyPath { get; set; }
         public Dictionary<string, List<string>> TraitMap { get; set; }
 
-        public TestCaseData(string displayName, string skipReason, string assemblyPath, Dictionary<string, List<string>> traitMap)
+        public TestCaseData(string displayName, string uniqueID, string skipReason, string assemblyPath, Dictionary<string, List<string>> traitMap)
         {
             DisplayName = displayName;
+            UniqueID = uniqueID;
             SkipReason = skipReason;
             AssemblyPath = assemblyPath;
             TraitMap = traitMap;
@@ -21,6 +23,7 @@ namespace Xunit.Runner.Data
         public static TestCaseData ReadFrom(BinaryReader reader)
         {
             var displayName = reader.ReadString();
+            var uniqueID = reader.ReadString();
             var skipReason = reader.ReadString();
             var assemblyPath = reader.ReadString();
             var count = reader.ReadInt32();
@@ -40,12 +43,13 @@ namespace Xunit.Runner.Data
                 traitMap.Add(key, values);
             }
 
-            return new TestCaseData(displayName, skipReason, assemblyPath, traitMap);
+            return new TestCaseData(displayName, uniqueID, skipReason, assemblyPath, traitMap);
         }
 
         public void WriteTo(BinaryWriter writer)
         {
             writer.Write(DisplayName);
+            writer.Write(UniqueID);
             writer.Write(SkipReason ?? string.Empty);
             writer.Write(AssemblyPath);
             writer.Write(TraitMap.Count);

--- a/xunit.runner.data/TestResultData.cs
+++ b/xunit.runner.data/TestResultData.cs
@@ -18,12 +18,14 @@ namespace Xunit.Runner.Data
     public sealed class TestResultData
     {
         public string TestCaseDisplayName { get; set; }
+        public string TestCaseUniqueID { get; set; }
         public TestState TestState { get; set; }
         public string Output { get; set; }
 
-        public TestResultData(string displayName, TestState state, string output = "")
+        public TestResultData(string displayName, string uniqueID, TestState state, string output = "")
         {
             TestCaseDisplayName = displayName;
+            TestCaseUniqueID = uniqueID;
             TestState = state;
             Output = output;
         }
@@ -31,14 +33,16 @@ namespace Xunit.Runner.Data
         public static TestResultData ReadFrom(BinaryReader reader)
         {
             var displayName = reader.ReadString();
+            var uniqueID = reader.ReadString();
             var state = (TestState)reader.ReadInt32();
             var output = reader.ReadString();
-            return new TestResultData(displayName, state, output);
+            return new TestResultData(displayName, uniqueID, state, output);
         }
 
         public void WriteTo(BinaryWriter writer)
         {
             writer.Write(TestCaseDisplayName);
+            writer.Write(TestCaseUniqueID);
             writer.Write((int)TestState);
             writer.Write(Output);
         }

--- a/xunit.runner.worker/DiscoverUtil.cs
+++ b/xunit.runner.worker/DiscoverUtil.cs
@@ -23,6 +23,7 @@ namespace Xunit.Runner.Worker
                 var testCase = testCaseDiscovered.TestCase;
                 var testCaseData = new TestCaseData(
                     testCase.DisplayName,
+                    testCase.UniqueID,
                     testCase.SkipReason,
                     testCaseDiscovered.TestAssembly.Assembly.AssemblyPath,
                     testCase.Traits);

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -594,7 +594,7 @@ namespace Xunit.Runner.Wpf.ViewModel
                     {
                         if (testCase.AssemblyFileName == assemblyFileName)
                         {
-                            builder.Add(testCase.DisplayName);
+                            builder.Add(testCase.UniqueID);
                         }
                     }
 
@@ -660,6 +660,7 @@ namespace Xunit.Runner.Wpf.ViewModel
 
                 var testCaseViewModel = new TestCaseViewModel(
                     testCase.DisplayName,
+                    testCase.UniqueID,
                     testCase.SkipReason,
                     testCase.AssemblyPath,
                     traitWorkerList);
@@ -679,7 +680,7 @@ namespace Xunit.Runner.Wpf.ViewModel
 
             foreach (var result in testResultData)
             {
-                var testCase = this.runningTests.Single(x => x.DisplayName == result.TestCaseDisplayName);
+                var testCase = this.runningTests.Single(x => x.UniqueID == result.TestCaseUniqueID);
                 testCase.State = result.TestState;
 
                 TestsCompleted++;

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -26,6 +26,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         private readonly Settings settings;
 
         private readonly ITestUtil testUtil;
+        private readonly HashSet<string> allTestCaseUniqueIDs = new HashSet<string>();
         private readonly ObservableCollection<TestCaseViewModel> allTestCases = new ObservableCollection<TestCaseViewModel>();
         private readonly TraitCollectionView traitCollectionView = new TraitCollectionView();
         private CancellationTokenSource filterCancellationTokenSource = new CancellationTokenSource();
@@ -446,6 +447,7 @@ namespace Xunit.Runner.Wpf.ViewModel
             {
                 if (string.Compare(this.allTestCases[i].AssemblyFileName, assemblyPath, StringComparison.OrdinalIgnoreCase) == 0)
                 {
+                    this.allTestCaseUniqueIDs.Remove(this.allTestCases[i].UniqueID);
                     this.allTestCases.RemoveAt(i);
                 }
                 else
@@ -638,6 +640,9 @@ namespace Xunit.Runner.Wpf.ViewModel
 
             foreach (var testCase in testCases)
             {
+                if (this.allTestCaseUniqueIDs.Contains(testCase.UniqueID))
+                    continue;
+
                 traitWorkerList.Clear();
 
                 // Get or create traits.
@@ -670,6 +675,7 @@ namespace Xunit.Runner.Wpf.ViewModel
                     TestsSkipped++;
                 }
 
+                this.allTestCaseUniqueIDs.Add(testCase.UniqueID);
                 this.allTestCases.Add(testCaseViewModel);
             }
         }

--- a/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/TestCaseViewModel.cs
@@ -10,6 +10,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         private TestState _state = TestState.NotRun;
 
         public string DisplayName { get; }
+        public string UniqueID { get; }
         public string SkipReason { get; }
         public string AssemblyFileName { get; }
         public ImmutableArray<TraitViewModel> Traits { get; }
@@ -23,9 +24,10 @@ namespace Xunit.Runner.Wpf.ViewModel
             set { Set(ref _state, value); }
         }
 
-        public TestCaseViewModel(string displayName, string skipReason, string assemblyFileName, IEnumerable<TraitViewModel> traits)
+        public TestCaseViewModel(string displayName, string uniqueID, string skipReason, string assemblyFileName, IEnumerable<TraitViewModel> traits)
         {
             this.DisplayName = displayName;
+            this.UniqueID = uniqueID;
             this.SkipReason = skipReason;
             this.AssemblyFileName = assemblyFileName;
             this.Traits = traits.ToImmutableArray();


### PR DESCRIPTION
* Use the unique ID instead of display name to differentiate tests
* Silently omit duplicates from the list of discovered tests to avoid crashes