### PR TITLE
Autoreload

### DIFF
--- a/SampleTestAssembly/SampleTestAssembly.csproj
+++ b/SampleTestAssembly/SampleTestAssembly.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -65,6 +66,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SampleTestAssembly/packages.config
+++ b/SampleTestAssembly/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/xunit.runner.data/xunit.runner.data.csproj
+++ b/xunit.runner.data/xunit.runner.data.csproj
@@ -48,6 +48,11 @@
     <Compile Include="TestDataKind.cs" />
     <Compile Include="TestResultData.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers">
+      <Version>2.2.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/xunit.runner.worker/packages.config
+++ b/xunit.runner.worker/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net46" developmentDependency="true" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.runner.utility" version="2.1.0" targetFramework="net46" />
 </packages>

--- a/xunit.runner.worker/xunit.runner.worker.csproj
+++ b/xunit.runner.worker/xunit.runner.worker.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -74,6 +77,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/xunit.runner.wpf/ITestAssemblyWatcher.cs
+++ b/xunit.runner.wpf/ITestAssemblyWatcher.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xunit.Runner.Wpf
+{
+    internal interface ITestAssemblyWatcher
+    {
+        /// <summary>
+        /// Adds a new assembly to list of assemblies to be autoreloaded.
+        /// </summary>
+        void AddAssembly(string assemblyFileName);
+
+        /// <summary>
+        /// Removes an assembly from the list of assemblies ot be autoreloaded.
+        /// </summary>
+        void RemoveAssembly(string assemblyFileName);
+
+        /// <summary>
+        /// Enables watching of all assemblies.
+        /// </summary>
+        /// <param name="reloader">Action to perform when a file change is detected</param>
+        void EnableWatch(Func<IEnumerable<string>, bool> reloader);
+
+        /// <summary>
+        /// Disables watching of all assemblies
+        /// </summary>
+        void DisableWatch();
+    }
+}

--- a/xunit.runner.wpf/Impl/TestAssemblyWatcher.cs
+++ b/xunit.runner.wpf/Impl/TestAssemblyWatcher.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+
+namespace Xunit.Runner.Wpf.Impl
+{
+    internal sealed class TestAssemblyWatcher : ITestAssemblyWatcher
+    {
+        private readonly object sync = new object();
+        private readonly IDictionary<string, FileSystemWatcher> watchedAssemblies = new Dictionary<string, FileSystemWatcher>();
+        private readonly Dispatcher dispatcher;
+        private bool isEnabled = false;
+        private ReloadDebouncer debouncer;
+
+        public TestAssemblyWatcher(Dispatcher dispatcher)
+        {
+            this.dispatcher = dispatcher;
+        }
+
+        public void AddAssembly(string assemblyFileName)
+        {
+            // Assumptions about adding and removing assemblies are broken if this isn't true
+            Debug.Assert(string.Equals(assemblyFileName, Path.GetFullPath(assemblyFileName), StringComparison.Ordinal));
+
+            lock (sync)
+            {
+                if (watchedAssemblies.ContainsKey(assemblyFileName))
+                {
+                    // Already watching this assembly, nothing to do but return
+                    return;
+                }
+
+                FileSystemWatcher watcher = new FileSystemWatcher
+                {
+                    Path = Path.GetDirectoryName(assemblyFileName),
+                    NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite,
+                    Filter = Path.GetFileName(assemblyFileName)
+                };
+
+                watcher.Changed += new FileSystemEventHandler(OnChanged);
+                watcher.Created += new FileSystemEventHandler(OnChanged);
+
+                watchedAssemblies[assemblyFileName] = watcher;
+
+                if (isEnabled)
+                {
+                    watcher.EnableRaisingEvents = true;
+                }
+            }
+        }
+
+        public void RemoveAssembly(string assemblyFileName)
+        {
+            lock (sync)
+            {
+                if (watchedAssemblies.ContainsKey(assemblyFileName))
+                {
+                    watchedAssemblies[assemblyFileName].Dispose();
+                    watchedAssemblies.Remove(assemblyFileName);
+                }
+            }
+        }
+
+        public void EnableWatch(Func<IEnumerable<string>, bool> reloader)
+        {
+            lock (sync)
+            {
+                isEnabled = true;
+
+                foreach (var watcher in watchedAssemblies.Values)
+                {
+                    watcher.EnableRaisingEvents = true;
+                }
+
+                this.debouncer = new ReloadDebouncer(dispatcher, reloader);
+            }
+        }
+
+        public void DisableWatch()
+        {
+            lock (sync)
+            {
+                isEnabled = false;
+
+                foreach (var watcher in watchedAssemblies.Values)
+                {
+                    watcher.EnableRaisingEvents = false;
+                }
+
+                this.debouncer?.Cancel();
+                this.debouncer = null;
+            }
+        }
+
+        private void OnChanged(object source, FileSystemEventArgs args)
+        {
+            debouncer?.AddAssembly(args.FullPath);
+        }
+
+        /// <summary>
+        /// Because, during a build of a number of projects many file system events will be triggered for potentially many
+        /// test assemblies, we need to batch our update requests. This class will do this, waiting for 100 ms after receiving
+        /// a new reload request to send the reload requests. This timer resets every time a reload request is received. Note
+        /// that if you continuously rebuild, this will technicially never finish batching and nothing will reload, but this
+        /// assumes that file events will stop at some point.
+        ///
+        /// If the reloader returns false, meaning that the reload was not kicked off successfully, we back off for a full second
+        /// before reattempting to queue the updates.
+        /// </summary>
+        private class ReloadDebouncer
+        {
+            private readonly object sync = new object();
+            private readonly Dispatcher dispatcher;
+            private readonly Func<IEnumerable<string>, bool> reloader;
+
+            private ISet<string> assembliesToReload = new HashSet<string>();
+            private bool newAssemblyAdded = false;
+            private bool running = false;
+            private bool cancelled = false;
+
+            public ReloadDebouncer(Dispatcher dispatcher, Func<IEnumerable<string>, bool> reloader)
+            {
+                this.dispatcher = dispatcher;
+                this.reloader = reloader;
+            }
+
+            public void AddAssembly(string assembly)
+            {
+                lock (sync)
+                {
+                    assembliesToReload.Add(assembly);
+
+                    if (!Start())
+                    {
+                        newAssemblyAdded = true;
+                    }
+                }
+            }
+
+            public void Cancel()
+            {
+                running = false;
+            }
+
+            private bool Start()
+            {
+                if (running)
+                {
+                    return false;
+                }
+
+                running = true;
+                Task.Run((Action)Debounce);
+                return true;
+            }
+
+            private async void Debounce()
+            {
+                bool backOff = false;
+
+                do
+                {
+                    await Task.Delay(backOff ? 1000 : 100);
+                    backOff = false;
+
+                    lock (sync)
+                    {
+                        void Reset()
+                        {
+                            assembliesToReload = new HashSet<string>();
+                            running = false;
+                        }
+
+                        if (cancelled)
+                        {
+                            Reset();
+                            return;
+                        }
+
+                        // New assemblies added, so we need to wait again
+                        if (newAssemblyAdded)
+                        {
+                            newAssemblyAdded = false;
+                            continue;
+                        }
+
+                        // No new assemblies added, time to alert and exit
+                        if (!dispatcher.Invoke(() => reloader(assembliesToReload)))
+                        {
+                            // If the reloader returned false, it's still busy from the last reload request or other user action.
+                            // Back off for a full second to give it time, then continue as previous
+                            backOff = true;
+                            continue;
+                        }
+                        Reset();
+                    }
+
+                } while (running);
+            }
+        }
+    }
+}

--- a/xunit.runner.wpf/MainWindow.xaml
+++ b/xunit.runner.wpf/MainWindow.xaml
@@ -61,6 +61,8 @@
                 <Separator />
                 <MenuItem Header="_Unload" Command="{Binding AssemblyRemoveAllCommand}"/>
                 <MenuItem Header="_Reload" Command="{Binding AssemblyReloadAllCommand}" />
+                <Separator />
+                <MenuItem Header="_Auto Reload Test Assemblies" IsCheckable="True" IsChecked="{Binding AutoReloadAssemblies}" Command="{Binding AutoReloadAssembliesCommand}" />
             </MenuItem>
             <MenuItem Header="_Project">
                 <MenuItem Header="_Open" />

--- a/xunit.runner.wpf/MainWindow.xaml
+++ b/xunit.runner.wpf/MainWindow.xaml
@@ -256,7 +256,7 @@
                                     <Image Source="Artwork\Failed_large.png" />
                                     <TextBlock Margin="4,0"
                                                FontSize="16"
-                                               Text="{Binding TestsFailed, StringFormat={}{0:#\,0}}" 
+                                               Text="{Binding TestsFailed, StringFormat={}{0:#\,0}}"
                                                VerticalAlignment="Center" />
                                 </StackPanel>
                             </ToggleButton>
@@ -271,7 +271,7 @@
                                     <Image Source="Artwork\Skipped_large.png" />
                                     <TextBlock Margin="4,0"
                                                FontSize="16"
-                                               Text="{Binding TestsSkipped, StringFormat={}{0:#\,0}}" 
+                                               Text="{Binding TestsSkipped, StringFormat={}{0:#\,0}}"
                                                VerticalAlignment="Center" />
                                 </StackPanel>
                             </ToggleButton>

--- a/xunit.runner.wpf/Persistence/Settings.cs
+++ b/xunit.runner.wpf/Persistence/Settings.cs
@@ -14,16 +14,19 @@ namespace Xunit.Runner.Wpf.Persistence
         private const string RecentAssemblyElementName = "recent_assembly";
         private const string SettingsElementName = "settings";
         private const string VersionAttributeName = "version";
+        private const string AutoReloadAssembliesElementName = "auto_reload_assemblies";
 
         private const int MaxRecentAssemblies = 10;
 
         private static readonly Version s_latestVersion = new Version(1, 0, 0, 0);
 
         private List<string> recentAssemblies;
+        private bool autoReloadAssemblies;
 
         private Settings()
         {
             recentAssemblies = new List<string>();
+            autoReloadAssemblies = true;
         }
 
         public void AddRecentAssembly(string filePath)
@@ -43,6 +46,13 @@ namespace Xunit.Runner.Wpf.Persistence
                 recentAssemblies.RemoveRange(MaxRecentAssemblies - 1, recentAssemblies.Count - MaxRecentAssemblies);
             }
         }
+
+        public void ToggleAutoReloadAssemblies()
+        {
+            autoReloadAssemblies = !autoReloadAssemblies;
+        }
+
+        public bool GetAutoReloadAssemblies() => autoReloadAssemblies;
 
         public ImmutableArray<string> GetRecentAssemblies()
         {
@@ -65,6 +75,8 @@ namespace Xunit.Runner.Wpf.Persistence
 
                     xml.Add(recentAssembliesElement);
                 }
+
+                xml.Add(new XElement(AutoReloadAssembliesElementName, autoReloadAssemblies));
 
                 xml.Save(xmlFile);
             }
@@ -101,6 +113,17 @@ namespace Xunit.Runner.Wpf.Persistence
                         var filePath = (string)recentAssemblyElement;
                         settings.AddRecentAssembly(filePath);
                     }
+                }
+
+                var autoReloadAssembliesElement = xml.Element(AutoReloadAssembliesElementName);
+                if (autoReloadAssembliesElement != null)
+                {
+                    if (!bool.TryParse(autoReloadAssembliesElement.Value, out var autoReloadAssemblies))
+                    {
+                        autoReloadAssemblies = true;
+                    }
+
+                    settings.autoReloadAssemblies = autoReloadAssemblies;
                 }
 
                 return settings;

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -17,7 +17,6 @@ using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Taskbar;
 using Xunit.Runner.Data;
 using Xunit.Runner.Wpf.Persistence;
-using System.Collections;
 
 namespace Xunit.Runner.Wpf.ViewModel
 {
@@ -458,10 +457,10 @@ namespace Xunit.Runner.Wpf.ViewModel
         }
 
         /// <summary>
-        /// Reloading an assembly could have changed the traits.  There is no easy way 
-        /// to selectively edit this list (traits can cross assembly boundaries).  Just 
+        /// Reloading an assembly could have changed the traits.  There is no easy way
+        /// to selectively edit this list (traits can cross assembly boundaries).  Just
         /// do a full reload instead.
-        /// way to 
+        /// way to
         /// </summary>
         private void RebuildTraits()
         {

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -462,6 +462,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         {
             foreach (var assembly in assemblies.ToList())
             {
+                assemblyWatcher.RemoveAssembly(assembly.FileName);
                 RemoveAssemblyTestCases(assembly.FileName);
                 Assemblies.Remove(assembly);
             }

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -25,6 +25,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         private readonly Settings settings;
 
         private readonly ITestUtil testUtil;
+        private readonly ITestAssemblyWatcher assemblyWatcher;
         private readonly HashSet<string> allTestCaseUniqueIDs = new HashSet<string>();
         private readonly ObservableCollection<TestCaseViewModel> allTestCases = new ObservableCollection<TestCaseViewModel>();
         private readonly TraitCollectionView traitCollectionView = new TraitCollectionView();
@@ -33,10 +34,21 @@ namespace Xunit.Runner.Wpf.ViewModel
         private CancellationTokenSource cancellationTokenSource;
         private bool isBusy;
         private SearchQuery searchQuery = new SearchQuery();
+        private bool autoReloadAssemblies;
 
         public ObservableCollection<TestAssemblyViewModel> Assemblies { get; } = new ObservableCollection<TestAssemblyViewModel>();
         public FilteredCollectionView<TestCaseViewModel, SearchQuery> FilteredTestCases { get; }
         public ObservableCollection<TraitViewModel> Traits => this.traitCollectionView.Collection;
+        public bool AutoReloadAssemblies
+        {
+            get => autoReloadAssemblies;
+            set
+            {
+                var oldVal = autoReloadAssemblies;
+                autoReloadAssemblies = value;
+                RaisePropertyChanged(nameof(AutoReloadAssemblies), oldVal, autoReloadAssemblies);
+            }
+        }
 
         public ObservableCollection<RecentAssemblyViewModel> RecentAssemblies { get; } = new ObservableCollection<RecentAssemblyViewModel>();
 
@@ -55,6 +67,7 @@ namespace Xunit.Runner.Wpf.ViewModel
         public ICommand AssemblyReloadAllCommand { get; }
         public ICommand AssemblyRemoveCommand { get; }
         public ICommand AssemblyRemoveAllCommand { get; }
+        public ICommand AutoReloadAssembliesCommand { get; }
 
         public CommandBindingCollection CommandBindings { get; }
 
@@ -70,13 +83,14 @@ namespace Xunit.Runner.Wpf.ViewModel
             CommandBindings = CreateCommandBindings();
 
             this.testUtil = new Xunit.Runner.Wpf.Impl.RemoteTestUtil(Dispatcher.CurrentDispatcher);
+            this.assemblyWatcher = new Impl.TestAssemblyWatcher(Dispatcher.CurrentDispatcher);
             this.TestCasesCaption = "Test Cases (0)";
 
             this.FilteredTestCases = new FilteredCollectionView<TestCaseViewModel, SearchQuery>(
                 allTestCases, TestCaseMatches, searchQuery, TestComparer.Instance);
 
             this.FilteredTestCases.CollectionChanged += TestCases_CollectionChanged;
-            
+
             this.ExitCommand = new RelayCommand(OnExecuteExit);
             this.WindowLoadedCommand = new RelayCommand(OnExecuteWindowLoaded);
             this.WindowClosingCommand = new RelayCommand<CancelEventArgs>(OnExecuteWindowClosing);
@@ -89,8 +103,10 @@ namespace Xunit.Runner.Wpf.ViewModel
             this.AssemblyReloadAllCommand = new RelayCommand(OnExecuteAssemblyReloadAll);
             this.AssemblyRemoveCommand = new RelayCommand(OnExecuteAssemblyRemove, CanExecuteAssemblyRemove);
             this.AssemblyRemoveAllCommand = new RelayCommand(OnExecuteAssemblyRemoveAll);
+            this.AutoReloadAssembliesCommand = new RelayCommand(OnToggleAutoReloadAssemblies);
 
             RebuildRecentAssembliesMenu();
+            AutoReloadAssemblies = this.settings.GetAutoReloadAssemblies();
         }
 
         private void RebuildRecentAssembliesMenu()
@@ -391,10 +407,24 @@ namespace Xunit.Runner.Wpf.ViewModel
                 foreach (var assemblyViewModel in newAssemblyViewModels)
                 {
                     assemblyViewModel.State = AssemblyState.Ready;
+                    assemblyWatcher.AddAssembly(assemblyViewModel.FileName);
                 }
 
                 RebuildRecentAssembliesMenu();
             }
+        }
+
+        public bool ReloadAssemblies(IEnumerable<string> assemblies)
+        {
+            if (IsBusy)
+            {
+                return false;
+            }
+
+            var testAssemblies = Assemblies.Where(assembly => assemblies.Contains(assembly.FileName));
+            Application.Current.Dispatcher.InvokeAsync(() => ReloadAssemblies(testAssemblies));
+
+            return true;
         }
 
         private async Task ReloadAssemblies(IEnumerable<TestAssemblyViewModel> assemblies)
@@ -763,6 +793,29 @@ namespace Xunit.Runner.Wpf.ViewModel
         private void OnExecuteAssemblyRemoveAll()
         {
             RemoveAssemblies(Assemblies.ToArray());
+        }
+        private void OnToggleAutoReloadAssemblies()
+        {
+            ToggleReloadAssemblies();
+        }
+
+        private void ToggleReloadAssemblies()
+        {
+            this.settings.ToggleAutoReloadAssemblies();
+            AutoReloadAssemblies = this.settings.GetAutoReloadAssemblies();
+            UpdateAutoReloadStatus();
+        }
+
+        private void UpdateAutoReloadStatus()
+        {
+            if (AutoReloadAssemblies)
+            {
+                assemblyWatcher.EnableWatch(ReloadAssemblies);
+            }
+            else
+            {
+                assemblyWatcher.DisableWatch();
+            }
         }
 
         public bool FilterPassedTests

--- a/xunit.runner.wpf/packages.config
+++ b/xunit.runner.wpf/packages.config
@@ -1,18 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net46" developmentDependency="true" />
   <package id="MvvmLight" version="5.3.0.0" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net46" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="net46" />
-  <package id="System.Collections" version="4.0.10" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
-  <package id="System.Diagnostics.Debug" version="4.0.10" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.10" targetFramework="net46" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net46" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime" version="4.0.20" targetFramework="net46" />
-  <package id="System.Runtime.Extensions" version="4.0.10" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.10" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0-preview1-25305-02" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="Tvl.NuGet.BuildTasks" version="1.0.0-alpha002" targetFramework="net46" developmentDependency="true" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net46" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net46" />

--- a/xunit.runner.wpf/xunit.runner.wpf.csproj
+++ b/xunit.runner.wpf/xunit.runner.wpf.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.props" Condition="Exists('..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -69,10 +70,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.4.0-preview1-25305-02\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
@@ -208,6 +209,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.props'))" />
     <Error Condition="!Exists('..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <Import Project="..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.targets" Condition="Exists('..\packages\Tvl.NuGet.BuildTasks.1.0.0-alpha002\build\Tvl.NuGet.BuildTasks.targets')" />
 </Project>

--- a/xunit.runner.wpf/xunit.runner.wpf.csproj
+++ b/xunit.runner.wpf/xunit.runner.wpf.csproj
@@ -107,6 +107,8 @@
     <Compile Include="Impl\RemoteTestUtil.Connection.cs" />
     <Compile Include="Impl\RemoteTestUtil.BackgroundRunner.cs" />
     <Compile Include="Impl\RemoteTestUtil.cs" />
+    <Compile Include="Impl\TestAssemblyWatcher.cs" />
+    <Compile Include="ITestAssemblyWatcher.cs" />
     <Compile Include="ITestUtil.cs" />
     <Compile Include="Persistence\Settings.cs" />
     <Compile Include="Persistence\Storage.cs" />


### PR DESCRIPTION
This PR adds autoreloading of test assemblies (on by default), using the `FileSystemWatcher` Windows api to do the notification.

* A new setting has been added, "Auto Reload Test Assemblies"
* When a new assembly is added, the `MainViewModel` tells the `ITestAssemblyWatcher` to watch it. When enabled, the `MainViewModel` provides a callback that the watcher will call when the file is created or written to. 
* When a test assembly is updated, it's added to a list of assemblies to be autoreloaded. Because file operations can actually cause many updates to be sent in quick succession, and building one test assembly likely means another might be built very soon, we batch updates. We wait 100 ms after receiving an update notification to ask for reload, resetting that timer every time a new update is requested.