### PR TITLE
Open solution in Visual Studio 2017

### DIFF
--- a/xunit.runner.wpf.sln
+++ b/xunit.runner.wpf.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.wpf", "xunit.runner.wpf\xunit.runner.wpf.csproj", "{34FB519C-FB49-4B31-ACA2-7F7879311BCF}"
 EndProject


### PR DESCRIPTION
Since the project is using features from C# 7, update the solution to open
by default in a version of Visual Studio that supports them.