### PR TITLE
Fix first open and default autoreload case

### DIFF
--- a/xunit.runner.wpf/Persistence/Settings.cs
+++ b/xunit.runner.wpf/Persistence/Settings.cs
@@ -125,6 +125,10 @@ namespace Xunit.Runner.Wpf.Persistence
 
                     settings.autoReloadAssemblies = autoReloadAssemblies;
                 }
+                else
+                {
+                    settings.autoReloadAssemblies = true;
+                }
 
                 return settings;
             }

--- a/xunit.runner.wpf/ViewModel/MainViewModel.cs
+++ b/xunit.runner.wpf/ViewModel/MainViewModel.cs
@@ -107,6 +107,7 @@ namespace Xunit.Runner.Wpf.ViewModel
 
             RebuildRecentAssembliesMenu();
             AutoReloadAssemblies = this.settings.GetAutoReloadAssemblies();
+            UpdateAutoReloadStatus();
         }
 
         private void RebuildRecentAssembliesMenu()


### PR DESCRIPTION
When opening, you need to check and uncheck autoreload. Also, first open (before settings had been written) had a small bug where the ui would default to autoreload, but the underlying code actually wouldn't be enabled.